### PR TITLE
Install and run daemon as burp user

### DIFF
--- a/burp2/SOURCES/burp.init
+++ b/burp2/SOURCES/burp.init
@@ -24,7 +24,7 @@ conffile=${CONFFILE-/etc/burp/burp-server.conf}
 start () {
     	status -p ${pidfile} ${burp} &>/dev/null && { echo "$prog is already running"; exit 1; }
 	echo -n $"Starting $prog: "
-	daemon --pidfile=${pidfile} ${burp} -c ${conffile}
+	daemon --user burp --pidfile=${pidfile} ${burp} -c ${conffile}
 	RETVAL=$?
 	echo
 	[ $RETVAL -eq 0 ] && touch ${lockfile}

--- a/burp2/SOURCES/burp.service
+++ b/burp2/SOURCES/burp.service
@@ -4,6 +4,7 @@ Documentation=man:burp(1)
 After=network.target nss-lookup.target syslog.target local-fs.target remote-fs.target
 
 [Service]
+User=burp
 Type=forking
 EnvironmentFile=-/etc/sysconfig/burp-server
 Environment=CONFIG=/etc/burp/burp-server.conf

--- a/burp2/SPECS/burp2.spec
+++ b/burp2/SPECS/burp2.spec
@@ -9,7 +9,7 @@
 Name:		burp2
 Summary:	A Network-based backup and restore program
 Version:	2.0.44
-Release:	1%{?dist}
+Release:	2%{?dist}
 Group:		Backup Server
 License:	AGPLv3 and BSD and GPLv2+ and LGPLv2+
 URL:		http://burp.grke.org/
@@ -88,6 +88,7 @@ Requires:	openssl-perl
 Provides:	burp-server = %{version}-%{release}
 Provides:	bedup = %{version}-%{release}
 Provides:	vss_strip = %{version}-%{release}
+Requires(pre):	shadow-utils
 
 
 %description server
@@ -185,6 +186,12 @@ rm %{buildroot}%{_sysconfdir}/burp/clientconfdir/testclient
 %{_initrddir}/burp
 %endif
 
+%pre server
+getent group burp >/dev/null || groupadd -r burp
+getent passwd burp >/dev/null || \
+    useradd -r -g burp -d /var/lib/burp -s /sbin/nologin \
+    -c "BURP server service user" burp
+
 %post server
 %if 0%{?fedora} >= 19 || 0%{?rhel} >= 7
 %systemd_post burp.service
@@ -213,6 +220,9 @@ fi
 
 
 %changelog
+* Fri Aug 05 2016 Patrick Brideau <pbrideau@kronostechnologies.com> - 2.0.44-2
+- Run daemon as burp user
+
 * Thu Aug 04 2016 Pierre Bourgin <pierre.bourgin@free.fr> - 2.0.44-1
 - Updated to latest released version
 


### PR DESCRIPTION
I've seen you thinking about using a dedicated user for burp
https://github.com/yopito/fedora-epel-pkg/blob/master/burp2/SPECS/burp2.spec#L5

```
# packaging notes:
#
# XXX Group "Backup Server" is unknown (f22+)
# XXX use a dedicated user for burp ?
# XXX SElinux stuff ?
# XXX remove packaging notes.
```

So here is how i did it, in case you want this.  I've followed the recommended way from the fedora project:
http://fedoraproject.org/wiki/Packaging%3aUsersAndGroups
